### PR TITLE
[ENG-12857] Fix issue with iOS 17.4

### DIFF
--- a/ios/RNPencilKit.m
+++ b/ios/RNPencilKit.m
@@ -76,8 +76,7 @@ RCT_EXPORT_MODULE()
 
 - (void)setToolPicker API_AVAILABLE(ios(13)) {
   RCTLogInfo(@"[RNPencilKit] creating tool bar!");
-  UIWindow *window = [[[UIApplication sharedApplication] delegate] window];
-  self.picker = [PKToolPicker sharedToolPickerForWindow:window];
+  self.picker = [[PKToolPicker alloc] init];
   [self.picker addObserver:self.canvas];
   [self.picker setVisible:true forFirstResponder:self.canvas];
   [self.canvas becomeFirstResponder];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-draw-canvas",
   "title": "React Native Draw Canvas",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Cross platform native draw canvas for both iOS and Android",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-draw-canvas",
   "title": "React Native Draw Canvas",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Cross platform native draw canvas for both iOS and Android",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# General

Fixes an issue which was causing the application to crash whenever a user focused on a text input field on a WebView.

- [Apple Documentation: sharedToolPickerForWindow (@deprecated)](https://developer.apple.com/documentation/pencilkit/pktoolpicker/3229967-sharedtoolpickerforwindow?language=objc)

## How?

- removed deprecated `sharedToolPickerForWindow` init method
- replaced with regular `init` call

## Why?

React Native instantiates all `NativeModules` as singletons early on in the application lifecycle. This in turn would call the `sharedToolPickerForWindow` init method, which would set the PencilKit tool picker on the application window.

**NOTE**: This was the old way to initialize and has since been deprecated.

<img width="464" alt="Screenshot 2024-02-21 at 8 18 49 PM" src="https://github.com/padlet/react-native-draw-canvas/assets/10716803/1a1612f5-8d89-4f40-94c2-82111572cbe4">
