### PR TITLE
Patch vulnerabilities Step 1: Plan

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,102 @@
+# DEPENDENCY UPGRADE PLAN
+
+## DEPENDENCY CLASSIFICATION
+
+**ALL 4 dependencies are PRODUCTION transitive dependencies** (NOT development dependencies):
+
+- **minimist**: Current versions 0.0.8, 1.2.0 → Target: 1.2.8
+- **shell-quote**: Current versions 1.6.1, 1.7.2 → Target: 1.8.3  
+- **hermes-engine**: Current version 0.2.1 → Target: 0.11.0
+- **logkitty**: Current version 0.6.1 → Target: 0.7.1
+
+These come through react-native (0.61.5) and its build toolchain, not as direct dependencies.
+
+## SECURITY STATUS
+
+From yarn audit, these dependencies have:
+- **HIGH severity vulnerabilities**: minimist, shell-quote, hermes-engine
+- **CRITICAL severity vulnerabilities**: hermes-engine (CVE-2021-24037)
+
+## UPGRADE STRATEGY
+
+**APPROACH**: Use yarn resolutions to override vulnerable versions while maintaining React Native 0.61.5 compatibility.
+
+**EXECUTION PLAN**:
+
+```
+Phase 1: Preparation
+├── Verify latest versions security status
+├── Check hermes-engine 0.11.0 compatibility with RN 0.61.5
+└── Backup current yarn.lock
+
+Phase 2: Implementation  
+├── Add yarn resolutions to package.json
+├── Run yarn install to apply resolutions
+└── Verify dependency tree updates
+
+Phase 3: Validation
+├── Test library build process
+├── Run any existing tests
+└── Verify no breaking changes
+```
+
+## INDIVIDUAL UPGRADE PLANS
+
+### minimist (0.0.8/1.2.0 → 1.2.8)
+- **Type**: Patch security update
+- **Risk**: LOW - backward compatible
+- **Changes needed**: 0 code changes expected
+
+### shell-quote (1.6.1/1.7.2 → 1.8.3) 
+- **Type**: Patch security update
+- **Risk**: LOW - backward compatible
+- **Changes needed**: 0 code changes expected
+
+### hermes-engine (0.2.1 → 0.11.0)
+- **Type**: Major version upgrade
+- **Risk**: MEDIUM - needs compatibility verification
+- **Changes needed**: 0-1 code changes expected
+- **Note**: Critical vulnerabilities require upgrade
+
+### logkitty (0.6.1 → 0.7.1)
+- **Type**: Minor version upgrade  
+- **Risk**: LOW - backward compatible
+- **Changes needed**: 0 code changes expected
+
+## RISK ASSESSMENT
+
+**Overall Risk**: LOW - using dependency overrides minimizes breaking changes
+**Code Changes**: Expected 0-1 modifications (well under 5 change threshold)
+**Compatibility**: Maintaining React Native 0.61.5 for library consumers
+
+## IMPLEMENTATION STEPS
+
+1. **Add yarn resolutions to package.json**:
+   ```json
+   "resolutions": {
+     "minimist": "1.2.8",
+     "shell-quote": "1.8.3",
+     "hermes-engine": "0.11.0",
+     "logkitty": "0.7.1"
+   }
+   ```
+
+2. **Apply resolutions**:
+   ```bash
+   yarn install
+   ```
+
+3. **Verify upgrades**:
+   ```bash
+   yarn audit
+   yarn list --pattern "minimist|shell-quote|hermes-engine|logkitty"
+   ```
+
+4. **Test compatibility**:
+   - Build the library
+   - Run any existing tests
+   - Verify no breaking changes
+
+## CONCLUSION
+
+No dependencies classified as DIFFICULT_TO_UPGRADE. All upgrades can be implemented using yarn resolutions with minimal risk and no expected code changes.

--- a/TASKS_COORDINATED.md
+++ b/TASKS_COORDINATED.md
@@ -1,0 +1,53 @@
+# COORDINATED IMPLEMENTATION TASKS
+
+**Purpose**: Task list for the coordinated implementation phase where all dependency upgrades are applied simultaneously using yarn resolutions. This is the critical synchronization point where all individual dependency upgrades come together.
+
+**Dependencies Involved**:
+- minimist: 0.0.8/1.2.0 → 1.2.8
+- shell-quote: 1.6.1/1.7.2 → 1.8.3
+- hermes-engine: 0.2.1 → 0.11.0
+- logkitty: 0.6.1 → 0.7.1
+
+**Risk Level**: MEDIUM - Coordinated atomic operation
+
+## TASK LIST
+
+### Pre-Implementation Backup
+- [ ] **COORD-1**: Create backup of current yarn.lock file
+
+### Implementation (ATOMIC OPERATION)
+- [ ] **COORD-2**: Add all yarn resolutions to package.json simultaneously:
+  ```json
+  "resolutions": {
+    "minimist": "1.2.8",
+    "shell-quote": "1.8.3",
+    "hermes-engine": "0.11.0",
+    "logkitty": "0.7.1"
+  }
+  ```
+
+### Application and Verification
+- [ ] **COORD-3**: Run 'yarn install' to apply all resolutions
+- [ ] **COORD-4**: Verify all target versions appear in yarn.lock
+- [ ] **COORD-5**: Run 'yarn audit' to confirm vulnerability resolution
+
+## INTEGRATION TESTING TASKS
+- [ ] **INTEG-1**: Test React Native library build process end-to-end
+- [ ] **INTEG-2**: Verify no dependency conflicts in resolution tree
+- [ ] **INTEG-3**: Test library functionality with all upgraded dependencies
+- [ ] **INTEG-4**: Run performance benchmarks if available
+- [ ] **INTEG-5**: Test compatibility with React Native 0.61.5 consumer apps
+- [ ] **INTEG-6**: Verify no breaking changes to library API
+
+## ROLLBACK PROCEDURES
+- [ ] **ROLLBACK-1**: Restore original yarn.lock if critical issues found
+- [ ] **ROLLBACK-2**: Remove yarn resolutions from package.json
+- [ ] **ROLLBACK-3**: Run 'yarn install' to restore original versions
+- [ ] **ROLLBACK-4**: Document rollback reason and alternative approach
+
+## CRITICAL NOTES
+- **PREREQUISITE**: All individual dependency compatibility tasks must be completed first
+- **ESPECIALLY**: hermes-engine compatibility must be confirmed before proceeding
+- **ATOMIC OPERATION**: All resolutions must be added together, not individually
+- **ROLLBACK READY**: Keep original yarn.lock for immediate rollback if needed
+- This phase gates the success of the entire upgrade process

--- a/TASKS_HERMES_ENGINE.md
+++ b/TASKS_HERMES_ENGINE.md
@@ -1,0 +1,39 @@
+# HERMES-ENGINE UPGRADE TASKS
+
+**Purpose**: Task list for upgrading hermes-engine from version 0.2.1 to 0.11.0 to resolve CRITICAL security vulnerabilities including CVE-2021-24037. This is a HIGH-RISK major version upgrade that requires thorough compatibility testing with React Native 0.61.5.
+
+**Current Version**: 0.2.1 (transitive dependency)
+**Target Version**: 0.11.0
+**Risk Level**: HIGH - Major version upgrade with critical vulnerabilities
+
+## TASK LIST
+
+### Security Verification
+- [ ] **VERIFY-HE-1**: Check npm security advisory for hermes-engine 0.11.0
+- [ ] **VERIFY-HE-2**: Confirm CVE-2021-24037 and other criticals are fixed
+
+### Compatibility Assessment (CRITICAL GATING TASKS)
+- [ ] **COMPAT-HE-1**: Research React Native 0.61.5 compatibility with hermes 0.11.0
+- [ ] **COMPAT-HE-2**: Check hermes-engine changelog for breaking changes (0.2.1→0.11.0)
+- [ ] **COMPAT-HE-3**: Test hermes-engine 0.11.0 in isolated environment first
+- [ ] **COMPAT-HE-4**: Verify iOS/Android platform compatibility
+
+### Implementation
+- [ ] **IMPL-HE-1**: Add "hermes-engine": "0.11.0" to yarn resolutions
+
+### Validation (EXTENSIVE TESTING REQUIRED)
+- [ ] **VALID-HE-1**: Verify hermes-engine 0.11.0 appears in dependency tree
+- [ ] **VALID-HE-2**: Test React Native build process (both platforms)
+- [ ] **VALID-HE-3**: Run any existing library functionality tests
+- [ ] **VALID-HE-4**: Test JavaScript execution performance
+
+### Documentation
+- [ ] **DOC-HE-1**: Record upgrade decision and compatibility findings
+
+## CRITICAL NOTES
+- **BLOCKING DEPENDENCY**: All compatibility tasks must pass before proceeding with coordinated implementation
+- This dependency has CRITICAL security vulnerabilities that require immediate attention
+- Major version jump (0.2.1 → 0.11.0) requires extensive testing
+- JavaScript engine upgrade may affect performance and compatibility
+- Part of coordinated upgrade with minimist, shell-quote, and logkitty
+- **ROLLBACK PLAN**: Must be ready to rollback if compatibility issues found

--- a/TASKS_LOGKITTY.md
+++ b/TASKS_LOGKITTY.md
@@ -1,0 +1,33 @@
+# LOGKITTY UPGRADE TASKS
+
+**Purpose**: Task list for upgrading logkitty from version 0.6.1 to 0.7.1 as part of the coordinated security upgrade. This is a low-risk minor version upgrade for Android logging functionality.
+
+**Current Version**: 0.6.1 (transitive dependency)
+**Target Version**: 0.7.1
+**Risk Level**: LOW - Minor version upgrade
+
+## TASK LIST
+
+### Security Verification
+- [ ] **VERIFY-LK-1**: Check npm security advisory for logkitty 0.7.1
+- [ ] **VERIFY-LK-2**: Confirm no known vulnerabilities in 0.7.1
+
+### Compatibility Assessment
+- [ ] **COMPAT-LK-1**: Verify 0.7.1 backward compatibility with 0.6.1 API
+- [ ] **COMPAT-LK-2**: Check changelog for breaking changes
+
+### Implementation
+- [ ] **IMPL-LK-1**: Add "logkitty": "0.7.1" to yarn resolutions
+
+### Validation
+- [ ] **VALID-LK-1**: Verify logkitty 0.7.1 appears in dependency tree
+- [ ] **VALID-LK-2**: Test Android logging functionality if used
+
+### Documentation
+- [ ] **DOC-LK-1**: Record upgrade decision and version rationale
+
+## NOTES
+- This dependency is used for Android logging and debugging
+- Minor version upgrade with low risk of breaking changes
+- Part of coordinated upgrade with minimist, shell-quote, and hermes-engine
+- Primarily affects development and debugging workflows

--- a/TASKS_MINIMIST.md
+++ b/TASKS_MINIMIST.md
@@ -1,0 +1,32 @@
+# MINIMIST UPGRADE TASKS
+
+**Purpose**: Task list for upgrading minimist from versions 0.0.8/1.2.0 to 1.2.8 to resolve HIGH severity security vulnerabilities. This is a low-risk patch security update that should maintain backward compatibility.
+
+**Current Version**: 0.0.8, 1.2.0 (transitive dependency)
+**Target Version**: 1.2.8
+**Risk Level**: LOW - Patch security update
+
+## TASK LIST
+
+### Security Verification
+- [ ] **VERIFY-MIN-1**: Check npm security advisory for minimist 1.2.8
+- [ ] **VERIFY-MIN-2**: Confirm no known vulnerabilities in 1.2.8
+
+### Compatibility Assessment
+- [ ] **COMPAT-MIN-1**: Verify 1.2.8 backward compatibility with 1.2.0 API
+- [ ] **COMPAT-MIN-2**: Check changelog for breaking changes
+
+### Implementation
+- [ ] **IMPL-MIN-1**: Add "minimist": "1.2.8" to yarn resolutions
+
+### Validation
+- [ ] **VALID-MIN-1**: Verify minimist 1.2.8 appears in dependency tree
+- [ ] **VALID-MIN-2**: Test any functionality that uses argument parsing
+
+### Documentation
+- [ ] **DOC-MIN-1**: Record upgrade decision and version rationale
+
+## NOTES
+- This dependency comes through React Native's build toolchain
+- Upgrade addresses security vulnerabilities without expected breaking changes
+- Part of coordinated upgrade with shell-quote, hermes-engine, and logkitty

--- a/TASKS_SHELL_QUOTE.md
+++ b/TASKS_SHELL_QUOTE.md
@@ -1,0 +1,33 @@
+# SHELL-QUOTE UPGRADE TASKS
+
+**Purpose**: Task list for upgrading shell-quote from versions 1.6.1/1.7.2 to 1.8.3 to resolve HIGH severity security vulnerabilities. This is a low-risk patch security update that should maintain backward compatibility.
+
+**Current Version**: 1.6.1, 1.7.2 (transitive dependency)
+**Target Version**: 1.8.3
+**Risk Level**: LOW - Patch security update
+
+## TASK LIST
+
+### Security Verification
+- [ ] **VERIFY-SQ-1**: Check npm security advisory for shell-quote 1.8.3
+- [ ] **VERIFY-SQ-2**: Confirm no known vulnerabilities in 1.8.3
+
+### Compatibility Assessment
+- [ ] **COMPAT-SQ-1**: Verify 1.8.3 backward compatibility with 1.7.2 API
+- [ ] **COMPAT-SQ-2**: Check changelog for breaking changes
+
+### Implementation
+- [ ] **IMPL-SQ-1**: Add "shell-quote": "1.8.3" to yarn resolutions
+
+### Validation
+- [ ] **VALID-SQ-1**: Verify shell-quote 1.8.3 appears in dependency tree
+- [ ] **VALID-SQ-2**: Test any shell command processing functionality
+
+### Documentation
+- [ ] **DOC-SQ-1**: Record upgrade decision and version rationale
+
+## NOTES
+- This dependency comes through React Native's build toolchain
+- Used for shell command processing and escaping
+- Upgrade addresses security vulnerabilities without expected breaking changes
+- Part of coordinated upgrade with minimist, hermes-engine, and logkitty

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-draw-canvas",
   "title": "React Native Draw Canvas",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Cross platform native draw canvas for both iOS and Android",
   "main": "index.js",
   "scripts": {
@@ -12,9 +12,7 @@
     "url": "git+https://github.com/padlet/react-native-draw-canvas.git",
     "baseUrl": "https://github.com/padlet/react-native-draw-canvas"
   },
-  "keywords": [
-    "react-native"
-  ],
+  "keywords": ["react-native"],
   "author": {
     "name": "Colin Teahan",
     "email": "colin@padlet.com"


### PR DESCRIPTION
# Description

This is the 1st in a chain of PRs to upgrade this package — react-native-draw-canvas — and use it in the mobile app.
All of the PRs in the chain will upgrade and lock a dependency where a critical vulnerability has been reported.

This PR lays out the plan for Claude Code to do the work.

The branch of the mobile app in which I tested this chain (at the last PR #19, with git tag `v1.3.0rc1`) can be found at https://github.com/padlet/rn-mobile-app/pull/6138. 

# Chain

#19 
#18 
#17 
#16 
https://github.com/padlet/react-native-draw-canvas/pull/15 👈
master