### PR TITLE
Step 3: Upgrade minimist so we patch vulnerabilities

### DIFF
--- a/TASKS_MINIMIST.md
+++ b/TASKS_MINIMIST.md
@@ -9,24 +9,35 @@
 ## TASK LIST
 
 ### Security Verification
-- [ ] **VERIFY-MIN-1**: Check npm security advisory for minimist 1.2.8
-- [ ] **VERIFY-MIN-2**: Confirm no known vulnerabilities in 1.2.8
+- [x] **VERIFY-MIN-1**: Check npm security advisory for minimist 1.2.8
+- [x] **VERIFY-MIN-2**: Confirm no known vulnerabilities in 1.2.8
 
 ### Compatibility Assessment
-- [ ] **COMPAT-MIN-1**: Verify 1.2.8 backward compatibility with 1.2.0 API
-- [ ] **COMPAT-MIN-2**: Check changelog for breaking changes
+- [x] **COMPAT-MIN-1**: Verify 1.2.8 backward compatibility with 1.2.0 API
+- [x] **COMPAT-MIN-2**: Check changelog for breaking changes
 
 ### Implementation
-- [ ] **IMPL-MIN-1**: Add "minimist": "1.2.8" to yarn resolutions
+- [x] **IMPL-MIN-1**: Add "minimist": "1.2.8" to yarn resolutions
 
 ### Validation
-- [ ] **VALID-MIN-1**: Verify minimist 1.2.8 appears in dependency tree
-- [ ] **VALID-MIN-2**: Test any functionality that uses argument parsing
+- [x] **VALID-MIN-1**: Verify minimist 1.2.8 appears in dependency tree
+- [x] **VALID-MIN-2**: Test any functionality that uses argument parsing
 
 ### Documentation
-- [ ] **DOC-MIN-1**: Record upgrade decision and version rationale
+- [x] **DOC-MIN-1**: Record upgrade decision and version rationale
 
 ## NOTES
 - This dependency comes through React Native's build toolchain
 - Upgrade addresses security vulnerabilities without expected breaking changes
 - Part of coordinated upgrade with shell-quote, hermes-engine, and logkitty
+
+## UPGRADE COMPLETED
+**Date**: 2025-07-28
+**Decision**: Successfully upgraded minimist from 0.0.8/1.2.0 to 1.2.8
+**Rationale**: 
+- Version 1.2.8 resolves prototype pollution vulnerability (GHSA-vh95-rmgr-6w4m)
+- No breaking changes identified between 1.2.0 and 1.2.8
+- Backward compatible API
+- Applied via yarn resolutions to force upgrade of transitive dependency
+- Verified no direct usage of minimist in project source code
+- Upgrade successful with minimist@1.2.8 now in dependency tree

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "react": "^17.0.2",
     "react-native": "^0.68.2",
     "typescript": "^3.7.5"
+  },
+  "resolutions": {
+    "minimist": "1.2.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,15 +3259,10 @@ minimatch@^3.0.2, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+minimist@0.0.8, minimist@1.2.8, minimist@^1.2.0:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 mixin-deep@^1.2.0:
   version "1.3.2"


### PR DESCRIPTION
# Description

This is the 3rd in a chain of PRs to upgrade this package — react-native-draw-canvas — and use it in the mobile app.
All of the PRs in the chain will upgrade and lock a dependency where a critical vulnerability has been reported.

The branch of the mobile app in which I tested this chain (at the last PR #19, with git tag `v1.3.0rc1`) can be found at https://github.com/padlet/rn-mobile-app/pull/6138. 

# Chain

#19 
#18 
#17 👈
#16 
https://github.com/padlet/react-native-draw-canvas/pull/15 
master