### PR TITLE
Remove RNFoundation dependency and bump to 1.2.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -122,7 +122,6 @@ def kotlin_version = getExtOrDefault('kotlin_version')
 dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
-  api project(':padlet_rn-foundation')
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation project(path: ':react-native-webview')
   testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-draw-canvas",
   "title": "React Native Draw Canvas",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Cross platform native draw canvas for both iOS and Android",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This version removes the `api project(':padlet_rn-foundation')` declaration which the main mobile app is currently patching (which shouldn't really be needed).